### PR TITLE
match hexadecimal numbers better

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
 			{
 				"id": "lua",
 				"extensions": [
-					".lua"
+					".lua",
+					".luacheckrc"
 				],
 				"aliases": [
 					"Lua",

--- a/syntaxes/lua.json
+++ b/syntaxes/lua.json
@@ -132,7 +132,7 @@
 		},
 		"number": {
 			"name": "constant.numeric.lua",
-			"match": "(?<![\\d.])\\s0x[a-fA-F\\d]+|\\b\\d+(\\.\\d+)?([eE]-?\\d+)?|\\.\\d+([eE]-?\\d+)?"
+			"match": "(?<![\\d.])\\b0x[a-fA-F\\d]+|\\b\\d+(\\.\\d+)?([eE]-?\\d+)?|\\.\\d+([eE]-?\\d+)?"
 		},
 		"single-quote-string": {
 			"name": "string.quoted.single.lua",


### PR DESCRIPTION
Hexadecimal numbers were not matched when placed beside symbols and newlines

Edit: Also included `.luacheckrc` files