### PR TITLE
Match constants word boundaries

### DIFF
--- a/syntaxes/lua.json
+++ b/syntaxes/lua.json
@@ -128,7 +128,7 @@
 		},
 		"constant": {
 			"name": "constant.language.lua",
-			"match": "nil|true|false|_G|_VERSION|\\.\\.\\."
+			"match": "\\b(nil|true|false|_G|_VERSION|\\.\\.\\.)\\b"
 		},
 		"number": {
 			"name": "constant.numeric.lua",


### PR DESCRIPTION
The regex would match the constants even with other letters and numbers attached to them specifically when placed after the constant.
Now it matches the constants only when not surrounded by letters and numbers